### PR TITLE
Use /me password change endpoint

### DIFF
--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,7 +1,11 @@
 // src/routes/user.routes.ts
 import { Router } from "express"
 import { authGuard } from "../middleware/auth.js"
-import { getUserById, updateUserProfile } from "../controllers/user.controller.js"
+import {
+  changeUserPassword,
+  getUserById,
+  updateUserProfile,
+} from "../controllers/user.controller.js"
 
 const router = Router()
 
@@ -10,5 +14,8 @@ router.get("/:id", getUserById)
 
 // Update own profile
 router.put("/:id", authGuard, updateUserProfile)
+
+// Change own password
+router.put("/me/password", authGuard, changeUserPassword)
 
 export default router


### PR DESCRIPTION
### Motivation
- Avoid relying on an `:id` URL parameter for password changes and ensure the operation always applies to the authenticated user.
- Simplify controller logic and enforce basic password validation when updating credentials.

### Description
- Changed the route from `PUT /api/users/:id/password` to `PUT /api/users/me/password` and wired `changeUserPassword` into `src/routes/user.routes.ts`.
- Updated `changeUserPassword` in `src/controllers/user.controller.ts` to use `req.userId` instead of URL params, removed redundant param checks, and updated the route comment to reflect `/me/password`.
- Added a `ChangePasswordBody` type and imported `bcryptjs` to perform `bcrypt.compare` for current password validation and `bcrypt.hash` for storing the new password, and updated Prisma usage to query/update by `req.userId`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881ee64430832e8077f9fcf68869c6)